### PR TITLE
Fix bug in resetEncounter

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -172,9 +172,7 @@ export default class TrackerView extends ItemView {
 
     resetEncounter() {
         for (let creature of this.creatures) {
-            this.updateCreature(creature, {
-                hp: creature.max
-            });
+            creature.hp = creature.max;
             this.setCreatureState(creature, true);
             const statuses = Array.from(creature.status);
             statuses.forEach((status) => {


### PR DESCRIPTION
Calling `updateCreature` *adds* `creature.max` to a creature's hp instead of *setting* the hp.
This fix manually sets HP to the maximum value.

(I have no ts knowledge so there might be a better solution ;))