### PR TITLE
Fix bug in display of XP in difficulty tooltip in note

### DIFF
--- a/src/encounter/ui/Encounter.svelte
+++ b/src/encounter/ui/Encounter.svelte
@@ -1,276 +1,262 @@
 <script lang="ts">
-    import { ExtraButtonComponent, Platform } from "obsidian";
-    import { START_ENCOUNTER } from "src/utils";
+  import { ExtraButtonComponent, Platform } from "obsidian";
+  import { START_ENCOUNTER } from "src/utils";
 
-    import { Creature } from "src/utils/creature";
-    import {
-        DifficultyReport,
-        encounterDifficulty,
-        formatDifficultyReport
-    } from "src/utils/encounter-difficulty";
-    import type InitiativeTracker from "src/main";
-    import type { StackRoller } from "../../../../obsidian-dice-roller/src/roller";
+  import { Creature } from "src/utils/creature";
+  import {
+    DifficultyReport,
+    encounterDifficulty,
+    formatDifficultyReport,
+  } from "src/utils/encounter-difficulty";
+  import type InitiativeTracker from "src/main";
+  import type { StackRoller } from "../../../../obsidian-dice-roller/src/roller";
 
-    export let plugin: InitiativeTracker;
+  export let plugin: InitiativeTracker;
 
-    export let name: string = "Encounter";
-    export let creatures: Map<Creature, number | string>;
-    export let players: string[];
-    export let party: string = null;
-    export let hide: string[] = [];
-    export let xp: number;
+  export let name: string = "Encounter";
+  export let creatures: Map<Creature, number | string>;
+  export let players: string[];
+  export let party: string = null;
+  export let hide: string[] = [];
+  export let xp: number;
 
-    export let playerLevels: number[];
+  export let playerLevels: number[];
 
-    const creatureMap: Map<Creature, number> = new Map();
-    const rollerMap: Map<Creature, StackRoller> = new Map();
-    let totalXP = [...creatureMap].reduce((a, c) => a + c[0].xp * c[1], 0);
+  const creatureMap: Map<Creature, number> = new Map();
+  const rollerMap: Map<Creature, StackRoller> = new Map();
 
-    for (let [creature, count] of creatures) {
-        let number: number = Number(count);
-        if (plugin.canUseDiceRoller) {
-            let roller = plugin.getRoller(`${count}`) as StackRoller;
-            roller.on("new-result", () => {
-                creatureMap.set(creature, roller.result);
-                totalXP = [...creatureMap].reduce(
-                    (a, c) => a + c[0].xp * c[1],
-                    0
-                );
-            });
-            rollerMap.set(creature, roller);
-            roller.roll();
-        } else {
-            creatureMap.set(creature, number);
-        }
+  for (let [creature, count] of creatures) {
+    let number: number = Number(count);
+    if (plugin.canUseDiceRoller) {
+      let roller = plugin.getRoller(`${count}`) as StackRoller;
+      roller.on("new-result", () => {
+        creatureMap.set(creature, roller.result);
+        totalXP = [...creatureMap].reduce((a, c) => a + c[0].xp * c[1], 0);
+      });
+      rollerMap.set(creature, roller);
+      roller.roll();
+    } else {
+      creatureMap.set(creature, number);
     }
-    let difficulty: DifficultyReport;
-    $: {
-        if (!isNaN(totalXP)) {
-            difficulty = encounterDifficulty(
-                playerLevels,
-                [...creatures].map((creature) => creature[0].xp)
-            );
-        }
+  }
+
+  let totalXP = [...creatureMap].reduce((a, c) => a + c[0].xp * c[1], 0);
+  let difficulty: DifficultyReport;
+  $: {
+    if (!isNaN(totalXP)) {
+      difficulty = encounterDifficulty(
+        playerLevels,
+        [...creatureMap]
+          .map((creature) => Array(creature[1]).fill(creature[0].xp))
+          .flat()
+      );
+    }
+  }
+
+  const openButton = (node: HTMLElement) => {
+    new ExtraButtonComponent(node).setIcon(START_ENCOUNTER);
+  };
+
+  const open = async () => {
+    if (!plugin.view) {
+      await plugin.addTrackerView();
     }
 
-    const openButton = (node: HTMLElement) => {
-        new ExtraButtonComponent(node).setIcon(START_ENCOUNTER);
-    };
+    const view = plugin.view;
+    const creatures: Creature[] = [...creatureMap]
+      .map(([creature, number]) => {
+        if (isNaN(Number(number)) || number < 1) return [creature];
+        return [...Array(number).keys()].map((v) => Creature.from(creature));
+      })
+      .flat();
 
-    const open = async () => {
-        if (!plugin.view) {
-            await plugin.addTrackerView();
-        }
+    view?.newEncounter({
+      party,
+      name,
+      players,
+      creatures,
+      xp,
+    });
+    plugin.app.workspace.revealLeaf(view.leaf);
+  };
 
-        const view = plugin.view;
-        const creatures: Creature[] = [...creatureMap]
-            .map(([creature, number]) => {
-                if (isNaN(Number(number)) || number < 1) return [creature];
-                return [...Array(number).keys()].map((v) =>
-                    Creature.from(creature)
-                );
-            })
-            .flat();
+  const addButton = (node: HTMLElement) => {
+    new ExtraButtonComponent(node).setIcon("plus-with-circle");
+  };
 
-        view?.newEncounter({
-            party,
-            name,
-            players,
-            creatures,
-            xp
-        });
-        plugin.app.workspace.revealLeaf(view.leaf);
-    };
+  const add = async (evt: MouseEvent) => {
+    if (!plugin.view) {
+      await plugin.addTrackerView();
+    }
+    const view = plugin.view;
+    const creatures: Creature[] = [...creatureMap]
+      .map(([creature, number]) => {
+        if (isNaN(Number(number)) || number < 1) return [creature];
+        return [...Array(number).keys()].map((v) => Creature.from(creature));
+      })
+      .flat();
+    view.addCreatures(creatures, true);
+  };
 
-    const addButton = (node: HTMLElement) => {
-        new ExtraButtonComponent(node).setIcon("plus-with-circle");
-    };
+  const rollerEl = (node: HTMLElement, creature: Creature) => {
+    if (
+      plugin.canUseDiceRoller &&
+      rollerMap.has(creature) &&
+      !rollerMap.get(creature)!.isStatic
+    ) {
+      node.appendChild(
+        rollerMap.get(creature)?.containerEl ??
+          createSpan({ text: `${creatureMap.get(creature)}` })
+      );
+    } else {
+      node.setText(`${creatureMap.get(creature)}`);
+    }
+  };
 
-    const add = async (evt: MouseEvent) => {
-        if (!plugin.view) {
-            await plugin.addTrackerView();
-        }
-        const view = plugin.view;
-        const creatures: Creature[] = [...creatureMap]
-            .map(([creature, number]) => {
-                if (isNaN(Number(number)) || number < 1) return [creature];
-                return [...Array(number).keys()].map((v) =>
-                    Creature.from(creature)
-                );
-            })
-            .flat();
-        view.addCreatures(creatures, true);
-    };
-
-    const rollerEl = (node: HTMLElement, creature: Creature) => {
-        if (
-            plugin.canUseDiceRoller &&
-            rollerMap.has(creature) &&
-            !rollerMap.get(creature)!.isStatic
-        ) {
-            node.appendChild(
-                rollerMap.get(creature)?.containerEl ??
-                    createSpan({ text: `${creatureMap.get(creature)}` })
-            );
-        } else {
-            node.setText(`${creatureMap.get(creature)}`);
-        }
-    };
-
-    const label = (creature: Creature) => {
-        if (!creature) return;
-        let label = [];
-        if (creature.hp) {
-            label.push(`HP: ${creature.hp}`);
-        }
-        if (creature.ac) {
-            label.push(`AC: ${creature.ac}`);
-        }
-        if (creature.modifier) {
-            label.push(`MOD: ${creature.modifier}`);
-        }
-        return `${label.join(", ")}`;
-    };
+  const label = (creature: Creature) => {
+    if (!creature) return;
+    let label = [];
+    if (creature.hp) {
+      label.push(`HP: ${creature.hp}`);
+    }
+    if (creature.ac) {
+      label.push(`AC: ${creature.ac}`);
+    }
+    if (creature.modifier) {
+      label.push(`MOD: ${creature.modifier}`);
+    }
+    return `${label.join(", ")}`;
+  };
 </script>
 
 <div class="encounter-instance">
-    <div class="encounter-name">
-        <h3 data-heading={name} class="initiative-tracker-name">{name}</h3>
-        <div class="icons">
-            <div use:openButton on:click={open} aria-label="Start Encounter" />
-            <div use:addButton on:click={add} aria-label="Add to Encounter" />
-        </div>
+  <div class="encounter-name">
+    <h3 data-heading={name} class="initiative-tracker-name">{name}</h3>
+    <div class="icons">
+      <div use:openButton on:click={open} aria-label="Start Encounter" />
+      <div use:addButton on:click={add} aria-label="Add to Encounter" />
     </div>
-    <div class="creatures-container">
-        {#if !hide.includes("players")}
-            {#if players instanceof Array && players.length}
-                <div class="encounter-creatures encounter-players">
-                    <h4>{party ? party : "Players"}</h4>
-                    <ul>
-                        {#each players as player}
-                            <li>
-                                <span>{player}</span>
-                            </li>
-                        {/each}
-                    </ul>
-                </div>
-            {:else if !players}
-                <div class="encounter-creatures encounter-players">
-                    <h4>No Players</h4>
-                </div>
-            {/if}
-        {/if}
-        <div class="encounter-creatures">
-            {#if !hide.includes("creatures")}
-                <h4>Creatures</h4>
-                {#if creatures.size}
-                    <ul>
-                        {#each [...creatures] as [creature, count]}
-                            <li
-                                aria-label={label(creature)}
-                                class="creature-li"
-                            >
-                                <strong use:rollerEl={creature} />
-                                <span>
-                                    {#if creature.display && creature.display != creature.name}
-                                        &nbsp;{creature.display}{count == 1
-                                            ? ""
-                                            : "s"} ({creature.name})
-                                    {:else}
-                                        &nbsp;{creature.name}{count == 1
-                                            ? ""
-                                            : "s"}
-                                    {/if}
-                                </span>
-                                {#if creature.xp && creatureMap.has(creature)}
-                                    <span class="xp-parent">
-                                        <span class="paren left">(</span>
-                                        <span class="xp-container">
-                                            <span class="xp number">
-                                                {creature.xp *
-                                                    creatureMap.get(creature)}
-                                            </span>
-                                            <span class="xp text">XP</span>
-                                        </span>
-                                        <span class="paren right">)</span>
-                                    </span>
-                                {/if}
-                            </li>
-                        {/each}
-                    </ul>
-                {:else}
-                    <strong>No creatures</strong>
-                {/if}
-            {/if}
+  </div>
+  <div class="creatures-container">
+    {#if !hide.includes("players")}
+      {#if players instanceof Array && players.length}
+        <div class="encounter-creatures encounter-players">
+          <h4>{party ? party : "Players"}</h4>
+          <ul>
+            {#each players as player}
+              <li>
+                <span>{player}</span>
+              </li>
+            {/each}
+          </ul>
         </div>
-        {#if plugin.data.displayDifficulty}
-            <div class="encounter-xp difficulty">
-                {#if totalXP > 0 && difficulty}
-                    <span
-                        aria-label={formatDifficultyReport(difficulty)}
-                        class={difficulty.difficulty.toLowerCase()}
-                    >
-                        <strong class="difficulty-label"
-                            >{difficulty.difficulty}</strong
-                        >
-                        <span class="xp-parent difficulty">
-                            <span class="paren left">(</span>
-                            <span class="xp-container">
-                                <span class="xp number">
-                                    {totalXP}
-                                </span>
-                                <span class="xp text">XP</span>
-                            </span>
-                            <span class="paren right">)</span>
-                        </span>
+      {:else if !players}
+        <div class="encounter-creatures encounter-players">
+          <h4>No Players</h4>
+        </div>
+      {/if}
+    {/if}
+    <div class="encounter-creatures">
+      {#if !hide.includes("creatures")}
+        <h4>Creatures</h4>
+        {#if creatures.size}
+          <ul>
+            {#each [...creatures] as [creature, count]}
+              <li aria-label={label(creature)} class="creature-li">
+                <strong use:rollerEl={creature} />
+                <span>
+                  {#if creature.display && creature.display != creature.name}
+                    &nbsp;{creature.display}{count == 1 ? "" : "s"} ({creature.name})
+                  {:else}
+                    &nbsp;{creature.name}{count == 1 ? "" : "s"}
+                  {/if}
+                </span>
+                {#if creature.xp && creatureMap.has(creature)}
+                  <span class="xp-parent">
+                    <span class="paren left">(</span>
+                    <span class="xp-container">
+                      <span class="xp number">
+                        {creature.xp * creatureMap.get(creature)}
+                      </span>
+                      <span class="xp text">XP</span>
                     </span>
+                    <span class="paren right">)</span>
+                  </span>
                 {/if}
-            </div>
+              </li>
+            {/each}
+          </ul>
+        {:else}
+          <strong>No creatures</strong>
         {/if}
+      {/if}
     </div>
+    {#if plugin.data.displayDifficulty}
+      <div class="encounter-xp difficulty">
+        {#if totalXP > 0 && difficulty}
+          <span
+            aria-label={formatDifficultyReport(difficulty)}
+            class={difficulty.difficulty.toLowerCase()}
+          >
+            <strong class="difficulty-label">{difficulty.difficulty}</strong>
+            <span class="xp-parent difficulty">
+              <span class="paren left">(</span>
+              <span class="xp-container">
+                <span class="xp number">
+                  {totalXP}
+                </span>
+                <span class="xp text">XP</span>
+              </span>
+              <span class="paren right">)</span>
+            </span>
+          </span>
+        {/if}
+      </div>
+    {/if}
+  </div>
 </div>
 
 <style>
-    .encounter-name {
-        display: flex;
-        justify-content: flex-start;
-        align-items: center;
-    }
-    .encounter-name .initiative-tracker-name {
-        margin: 0;
-    }
-    .encounter-instance
-        > .creatures-container
-        > .encounter-creatures:first-of-type
-        h4,
-    .encounter-creatures > ul {
-        margin-top: 0;
-    }
-    .creature-li {
-        width: fit-content;
-    }
-    .xp-parent {
-        display: inline-flex;
-    }
-    .difficulty {
-        width: fit-content;
-    }
-    .deadly .difficulty-label {
-        color: red;
-    }
-    .hard .difficulty-label {
-        color: orange;
-    }
-    .medium .difficulty-label {
-        color: yellow;
-    }
-    .easy .difficulty-label {
-        color: green;
-    }
-    .icons {
-        display: flex;
-    }
-    .icons > div:first-child :global(.clickable-icon) {
-        margin-right: 0;
-    }
+  .encounter-name {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+  }
+  .encounter-name .initiative-tracker-name {
+    margin: 0;
+  }
+  .encounter-instance
+    > .creatures-container
+    > .encounter-creatures:first-of-type
+    h4,
+  .encounter-creatures > ul {
+    margin-top: 0;
+  }
+  .creature-li {
+    width: fit-content;
+  }
+  .xp-parent {
+    display: inline-flex;
+  }
+  .difficulty {
+    width: fit-content;
+  }
+  .deadly .difficulty-label {
+    color: red;
+  }
+  .hard .difficulty-label {
+    color: orange;
+  }
+  .medium .difficulty-label {
+    color: yellow;
+  }
+  .easy .difficulty-label {
+    color: green;
+  }
+  .icons {
+    display: flex;
+  }
+  .icons > div:first-child :global(.clickable-icon) {
+    margin-right: 0;
+  }
 </style>

--- a/src/encounter/ui/Encounter.svelte
+++ b/src/encounter/ui/Encounter.svelte
@@ -1,262 +1,279 @@
 <script lang="ts">
-  import { ExtraButtonComponent, Platform } from "obsidian";
-  import { START_ENCOUNTER } from "src/utils";
+    import { ExtraButtonComponent, Platform } from "obsidian";
+    import { START_ENCOUNTER } from "src/utils";
 
-  import { Creature } from "src/utils/creature";
-  import {
-    DifficultyReport,
-    encounterDifficulty,
-    formatDifficultyReport,
-  } from "src/utils/encounter-difficulty";
-  import type InitiativeTracker from "src/main";
-  import type { StackRoller } from "../../../../obsidian-dice-roller/src/roller";
+    import { Creature } from "src/utils/creature";
+    import {
+        DifficultyReport,
+        encounterDifficulty,
+        formatDifficultyReport
+    } from "src/utils/encounter-difficulty";
+    import type InitiativeTracker from "src/main";
+    import type { StackRoller } from "../../../../obsidian-dice-roller/src/roller";
 
-  export let plugin: InitiativeTracker;
+    export let plugin: InitiativeTracker;
 
-  export let name: string = "Encounter";
-  export let creatures: Map<Creature, number | string>;
-  export let players: string[];
-  export let party: string = null;
-  export let hide: string[] = [];
-  export let xp: number;
+    export let name: string = "Encounter";
+    export let creatures: Map<Creature, number | string>;
+    export let players: string[];
+    export let party: string = null;
+    export let hide: string[] = [];
+    export let xp: number;
 
-  export let playerLevels: number[];
+    export let playerLevels: number[];
 
-  const creatureMap: Map<Creature, number> = new Map();
-  const rollerMap: Map<Creature, StackRoller> = new Map();
+    const creatureMap: Map<Creature, number> = new Map();
+    const rollerMap: Map<Creature, StackRoller> = new Map();
 
-  for (let [creature, count] of creatures) {
-    let number: number = Number(count);
-    if (plugin.canUseDiceRoller) {
-      let roller = plugin.getRoller(`${count}`) as StackRoller;
-      roller.on("new-result", () => {
-        creatureMap.set(creature, roller.result);
-        totalXP = [...creatureMap].reduce((a, c) => a + c[0].xp * c[1], 0);
-      });
-      rollerMap.set(creature, roller);
-      roller.roll();
-    } else {
-      creatureMap.set(creature, number);
-    }
-  }
-
-  let totalXP = [...creatureMap].reduce((a, c) => a + c[0].xp * c[1], 0);
-  let difficulty: DifficultyReport;
-  $: {
-    if (!isNaN(totalXP)) {
-      difficulty = encounterDifficulty(
-        playerLevels,
-        [...creatureMap]
-          .map((creature) => Array(creature[1]).fill(creature[0].xp))
-          .flat()
-      );
-    }
-  }
-
-  const openButton = (node: HTMLElement) => {
-    new ExtraButtonComponent(node).setIcon(START_ENCOUNTER);
-  };
-
-  const open = async () => {
-    if (!plugin.view) {
-      await plugin.addTrackerView();
+    for (let [creature, count] of creatures) {
+        let number: number = Number(count);
+        if (plugin.canUseDiceRoller) {
+            let roller = plugin.getRoller(`${count}`) as StackRoller;
+            roller.on("new-result", () => {
+                creatureMap.set(creature, roller.result);
+                totalXP = [...creatureMap].reduce(
+                    (a, c) => a + c[0].xp * c[1],
+                    0
+                );
+            });
+            rollerMap.set(creature, roller);
+            roller.roll();
+        } else {
+            creatureMap.set(creature, number);
+        }
     }
 
-    const view = plugin.view;
-    const creatures: Creature[] = [...creatureMap]
-      .map(([creature, number]) => {
-        if (isNaN(Number(number)) || number < 1) return [creature];
-        return [...Array(number).keys()].map((v) => Creature.from(creature));
-      })
-      .flat();
-
-    view?.newEncounter({
-      party,
-      name,
-      players,
-      creatures,
-      xp,
-    });
-    plugin.app.workspace.revealLeaf(view.leaf);
-  };
-
-  const addButton = (node: HTMLElement) => {
-    new ExtraButtonComponent(node).setIcon("plus-with-circle");
-  };
-
-  const add = async (evt: MouseEvent) => {
-    if (!plugin.view) {
-      await plugin.addTrackerView();
+    let totalXP = [...creatureMap].reduce((a, c) => a + c[0].xp * c[1], 0);
+    let difficulty: DifficultyReport;
+    $: {
+        if (!isNaN(totalXP)) {
+            difficulty = encounterDifficulty(
+                playerLevels,
+                [...creatureMap]
+                .map((creature) => Array(creature[1]).fill(creature[0].xp))
+                .flat()
+        );
+        }
     }
-    const view = plugin.view;
-    const creatures: Creature[] = [...creatureMap]
-      .map(([creature, number]) => {
-        if (isNaN(Number(number)) || number < 1) return [creature];
-        return [...Array(number).keys()].map((v) => Creature.from(creature));
-      })
-      .flat();
-    view.addCreatures(creatures, true);
-  };
 
-  const rollerEl = (node: HTMLElement, creature: Creature) => {
-    if (
-      plugin.canUseDiceRoller &&
-      rollerMap.has(creature) &&
-      !rollerMap.get(creature)!.isStatic
-    ) {
-      node.appendChild(
-        rollerMap.get(creature)?.containerEl ??
-          createSpan({ text: `${creatureMap.get(creature)}` })
-      );
-    } else {
-      node.setText(`${creatureMap.get(creature)}`);
-    }
-  };
+    const openButton = (node: HTMLElement) => {
+        new ExtraButtonComponent(node).setIcon(START_ENCOUNTER);
+    };
 
-  const label = (creature: Creature) => {
-    if (!creature) return;
-    let label = [];
-    if (creature.hp) {
-      label.push(`HP: ${creature.hp}`);
-    }
-    if (creature.ac) {
-      label.push(`AC: ${creature.ac}`);
-    }
-    if (creature.modifier) {
-      label.push(`MOD: ${creature.modifier}`);
-    }
-    return `${label.join(", ")}`;
-  };
+    const open = async () => {
+        if (!plugin.view) {
+            await plugin.addTrackerView();
+        }
+
+        const view = plugin.view;
+        const creatures: Creature[] = [...creatureMap]
+            .map(([creature, number]) => {
+                if (isNaN(Number(number)) || number < 1) return [creature];
+                return [...Array(number).keys()].map((v) =>
+                    Creature.from(creature)
+                );
+            })
+            .flat();
+
+        view?.newEncounter({
+            party,
+            name,
+            players,
+            creatures,
+            xp
+        });
+        plugin.app.workspace.revealLeaf(view.leaf);
+    };
+
+    const addButton = (node: HTMLElement) => {
+        new ExtraButtonComponent(node).setIcon("plus-with-circle");
+    };
+
+    const add = async (evt: MouseEvent) => {
+        if (!plugin.view) {
+            await plugin.addTrackerView();
+        }
+        const view = plugin.view;
+        const creatures: Creature[] = [...creatureMap]
+            .map(([creature, number]) => {
+                if (isNaN(Number(number)) || number < 1) return [creature];
+                return [...Array(number).keys()].map((v) =>
+                    Creature.from(creature)
+                );
+            })
+            .flat();
+        view.addCreatures(creatures, true);
+    };
+
+    const rollerEl = (node: HTMLElement, creature: Creature) => {
+        if (
+            plugin.canUseDiceRoller &&
+            rollerMap.has(creature) &&
+            !rollerMap.get(creature)!.isStatic
+        ) {
+            node.appendChild(
+                rollerMap.get(creature)?.containerEl ??
+                    createSpan({ text: `${creatureMap.get(creature)}` })
+            );
+        } else {
+            node.setText(`${creatureMap.get(creature)}`);
+        }
+    };
+
+    const label = (creature: Creature) => {
+        if (!creature) return;
+        let label = [];
+        if (creature.hp) {
+            label.push(`HP: ${creature.hp}`);
+        }
+        if (creature.ac) {
+            label.push(`AC: ${creature.ac}`);
+        }
+        if (creature.modifier) {
+            label.push(`MOD: ${creature.modifier}`);
+        }
+        return `${label.join(", ")}`;
+    };
 </script>
 
 <div class="encounter-instance">
-  <div class="encounter-name">
-    <h3 data-heading={name} class="initiative-tracker-name">{name}</h3>
-    <div class="icons">
-      <div use:openButton on:click={open} aria-label="Start Encounter" />
-      <div use:addButton on:click={add} aria-label="Add to Encounter" />
+    <div class="encounter-name">
+        <h3 data-heading={name} class="initiative-tracker-name">{name}</h3>
+        <div class="icons">
+            <div use:openButton on:click={open} aria-label="Start Encounter" />
+            <div use:addButton on:click={add} aria-label="Add to Encounter" />
+        </div>
     </div>
-  </div>
-  <div class="creatures-container">
-    {#if !hide.includes("players")}
-      {#if players instanceof Array && players.length}
-        <div class="encounter-creatures encounter-players">
-          <h4>{party ? party : "Players"}</h4>
-          <ul>
-            {#each players as player}
-              <li>
-                <span>{player}</span>
-              </li>
-            {/each}
-          </ul>
-        </div>
-      {:else if !players}
-        <div class="encounter-creatures encounter-players">
-          <h4>No Players</h4>
-        </div>
-      {/if}
-    {/if}
-    <div class="encounter-creatures">
-      {#if !hide.includes("creatures")}
-        <h4>Creatures</h4>
-        {#if creatures.size}
-          <ul>
-            {#each [...creatures] as [creature, count]}
-              <li aria-label={label(creature)} class="creature-li">
-                <strong use:rollerEl={creature} />
-                <span>
-                  {#if creature.display && creature.display != creature.name}
-                    &nbsp;{creature.display}{count == 1 ? "" : "s"} ({creature.name})
-                  {:else}
-                    &nbsp;{creature.name}{count == 1 ? "" : "s"}
-                  {/if}
-                </span>
-                {#if creature.xp && creatureMap.has(creature)}
-                  <span class="xp-parent">
-                    <span class="paren left">(</span>
-                    <span class="xp-container">
-                      <span class="xp number">
-                        {creature.xp * creatureMap.get(creature)}
-                      </span>
-                      <span class="xp text">XP</span>
-                    </span>
-                    <span class="paren right">)</span>
-                  </span>
+    <div class="creatures-container">
+        {#if !hide.includes("players")}
+            {#if players instanceof Array && players.length}
+                <div class="encounter-creatures encounter-players">
+                    <h4>{party ? party : "Players"}</h4>
+                    <ul>
+                        {#each players as player}
+                            <li>
+                                <span>{player}</span>
+                            </li>
+                        {/each}
+                    </ul>
+                </div>
+            {:else if !players}
+                <div class="encounter-creatures encounter-players">
+                    <h4>No Players</h4>
+                </div>
+            {/if}
+        {/if}
+        <div class="encounter-creatures">
+            {#if !hide.includes("creatures")}
+                <h4>Creatures</h4>
+                {#if creatures.size}
+                    <ul>
+                        {#each [...creatures] as [creature, count]}
+                            <li
+                                aria-label={label(creature)}
+                                class="creature-li"
+                            >
+                                <strong use:rollerEl={creature} />
+                                <span>
+                                    {#if creature.display && creature.display != creature.name}
+                                        &nbsp;{creature.display}{count == 1
+                                            ? ""
+                                            : "s"} ({creature.name})
+                                    {:else}
+                                        &nbsp;{creature.name}{count == 1
+                                            ? ""
+                                            : "s"}
+                                    {/if}
+                                </span>
+                                {#if creature.xp && creatureMap.has(creature)}
+                                    <span class="xp-parent">
+                                        <span class="paren left">(</span>
+                                        <span class="xp-container">
+                                            <span class="xp number">
+                                                {creature.xp *
+                                                    creatureMap.get(creature)}
+                                            </span>
+                                            <span class="xp text">XP</span>
+                                        </span>
+                                        <span class="paren right">)</span>
+                                    </span>
+                                {/if}
+                            </li>
+                        {/each}
+                    </ul>
+                {:else}
+                    <strong>No creatures</strong>
                 {/if}
-              </li>
-            {/each}
-          </ul>
-        {:else}
-          <strong>No creatures</strong>
+            {/if}
+        </div>
+        {#if plugin.data.displayDifficulty}
+            <div class="encounter-xp difficulty">
+                {#if totalXP > 0 && difficulty}
+                    <span
+                        aria-label={formatDifficultyReport(difficulty)}
+                        class={difficulty.difficulty.toLowerCase()}
+                    >
+                        <strong class="difficulty-label"
+                            >{difficulty.difficulty}</strong
+                        >
+                        <span class="xp-parent difficulty">
+                            <span class="paren left">(</span>
+                            <span class="xp-container">
+                                <span class="xp number">
+                                    {totalXP}
+                                </span>
+                                <span class="xp text">XP</span>
+                            </span>
+                            <span class="paren right">)</span>
+                        </span>
+                    </span>
+                {/if}
+            </div>
         {/if}
-      {/if}
     </div>
-    {#if plugin.data.displayDifficulty}
-      <div class="encounter-xp difficulty">
-        {#if totalXP > 0 && difficulty}
-          <span
-            aria-label={formatDifficultyReport(difficulty)}
-            class={difficulty.difficulty.toLowerCase()}
-          >
-            <strong class="difficulty-label">{difficulty.difficulty}</strong>
-            <span class="xp-parent difficulty">
-              <span class="paren left">(</span>
-              <span class="xp-container">
-                <span class="xp number">
-                  {totalXP}
-                </span>
-                <span class="xp text">XP</span>
-              </span>
-              <span class="paren right">)</span>
-            </span>
-          </span>
-        {/if}
-      </div>
-    {/if}
-  </div>
 </div>
 
 <style>
-  .encounter-name {
-    display: flex;
-    justify-content: flex-start;
-    align-items: center;
-  }
-  .encounter-name .initiative-tracker-name {
-    margin: 0;
-  }
-  .encounter-instance
-    > .creatures-container
-    > .encounter-creatures:first-of-type
-    h4,
-  .encounter-creatures > ul {
-    margin-top: 0;
-  }
-  .creature-li {
-    width: fit-content;
-  }
-  .xp-parent {
-    display: inline-flex;
-  }
-  .difficulty {
-    width: fit-content;
-  }
-  .deadly .difficulty-label {
-    color: red;
-  }
-  .hard .difficulty-label {
-    color: orange;
-  }
-  .medium .difficulty-label {
-    color: yellow;
-  }
-  .easy .difficulty-label {
-    color: green;
-  }
-  .icons {
-    display: flex;
-  }
-  .icons > div:first-child :global(.clickable-icon) {
-    margin-right: 0;
-  }
+    .encounter-name {
+        display: flex;
+        justify-content: flex-start;
+        align-items: center;
+    }
+    .encounter-name .initiative-tracker-name {
+        margin: 0;
+    }
+    .encounter-instance
+        > .creatures-container
+        > .encounter-creatures:first-of-type
+        h4,
+    .encounter-creatures > ul {
+        margin-top: 0;
+    }
+    .creature-li {
+        width: fit-content;
+    }
+    .xp-parent {
+        display: inline-flex;
+    }
+    .difficulty {
+        width: fit-content;
+    }
+    .deadly .difficulty-label {
+        color: red;
+    }
+    .hard .difficulty-label {
+        color: orange;
+    }
+    .medium .difficulty-label {
+        color: yellow;
+    }
+    .easy .difficulty-label {
+        color: green;
+    }
+    .icons {
+        display: flex;
+    }
+    .icons > div:first-child :global(.clickable-icon) {
+        margin-right: 0;
+    }
 </style>


### PR DESCRIPTION
Fixes #26 

The XP in the tooltip within the note is incorrectly calculated (see [here](https://github.com/valentine195/obsidian-initiative-tracker/blob/master/src/encounter/ui/Encounter.svelte#L46-L54)). This PR fixes the following issues

1. The XP values are added without considering the number of creatures. 
2. The `totalXP` is calculated from an empty `Map`.
3. Currently the `creatures` instead of the `creatureMap` object is used. The latter is modified if dice rolling is enabled and thus should be used. 

Fixes:

1. use `creatureMap` instead of `creatures`
2. calculate `totalXP` after populating `creatureMap` and use `creatureMap` as source.
3. use `creatureMap` to compute difficulty and consider number of creatures. This is done by creating an array that has repeated entries for the same creature if it is present more than once. 