### PR TITLE
QOL updates for HP management, visibility update for obsidian dark theme

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -95,6 +95,8 @@ export interface InitiativeTrackerData {
     state: InitiativeViewState;
     encounters: { [key: string]: InitiativeViewState };
     condense: boolean;
+    clamp: boolean;
+    autoStatus: boolean;
     warnedAboutImports: boolean;
 }
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -134,6 +134,28 @@ export default class InitiativeTrackerSettings extends PluginSettingTab {
                     await this.plugin.saveSettings();
                 });
             });
+            new Setting(containerEl)
+            .setName("Clamp Minimum HP")
+            .setDesc(
+                "When a creature takes damage that would reduce its HP below 0, its HP is set to 0 instead."
+            )
+            .addToggle((t) => {
+                t.setValue(this.plugin.data.clamp).onChange(async (v) => {
+                    this.plugin.data.clamp = v;
+                    await this.plugin.saveSettings();
+                });
+            });
+            new Setting(containerEl)
+            .setName("Automatic Unconscious Status Application")
+            .setDesc(
+                "When a creature takes damage that would reduce its HP below 0, it gains the \"Unconscious\" status effect."
+            )
+            .addToggle((t) => {
+                t.setValue(this.plugin.data.autoStatus).onChange(async (v) => {
+                    this.plugin.data.autoStatus = v;
+                    await this.plugin.saveSettings();
+                });
+            });
 
         /*         new Setting(containerEl)
             .setName("Monster Property used for Modifier")

--- a/src/svelte/Table.svelte
+++ b/src/svelte/Table.svelte
@@ -205,6 +205,9 @@
     .initiative-tracker-creature.active {
         background-color: rgba(0, 0, 0, 0.1);
     }
+    :global(.theme-dark) .initiative-tracker-creature.active {
+        background-color: rgba(255, 255, 255, 0.1);
+    }
     .initiative-tracker-creature.disabled :global(*) {
         color: var(--text-faint);
     }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -29,6 +29,8 @@ export const DEFAULT_SETTINGS: InitiativeTrackerData = {
         round: null
     },
     condense: false,
+    clamp: false,
+    autoStatus: false,
     displayDifficulty: true,
     encounters: {},
     warnedAboutImports: false,

--- a/src/view.ts
+++ b/src/view.ts
@@ -394,10 +394,15 @@ export default class TrackerView extends ItemView {
         const previous = [...this.ordered].slice(0, active).reverse();
         const after = [...this.ordered].slice(active + 1).reverse();
         const creature = [...previous, ...after].find((c) => c.enabled);
-        if (this.ordered[active]) this.ordered[active].active = false;
         if (!creature) return;
-        if (active < this.ordered.indexOf(creature))
-            this.round = Math.max(1, this.round - 1);
+        if (active < this.ordered.indexOf(creature)) {
+            if (this.round == 1) {
+                return;
+            }
+            this.round = this.round - 1;
+            
+        }
+        if (this.ordered[active]) this.ordered[active].active = false;
         creature.active = true;
         this.trigger("initiative-tracker:active-change", creature);
         this.setAppState({
@@ -466,7 +471,16 @@ export default class TrackerView extends ItemView {
             creature.number = 0;
         }
         if (hp) {
+            if (this.plugin.data.clamp && creature.hp + Number(hp) < 0) {
+                hp = -creature.hp;
+            }
             creature.hp += Number(hp);
+            if (this.plugin.data.autoStatus && creature.hp <= 0) {
+                this.addStatus(
+                    creature,
+                    this.plugin.data.statuses.find((s) => s.name == "Unconscious")
+                );
+            }
         }
         if (max) {
             if (creature.hp == creature.max) {


### PR DESCRIPTION
Static changes:
- Active creature highlighting in table made more clear when using Obsidian's dark theme, former hightlighting exists as base case for any other themes
- When attempting to move backwards in the initative order during round 1, the active creature stops at the first creature in the list, instead of wrapping
  - Behaviour for other rounds remain unchanged

The following features are added as toggleable settings:
- Clamping minimum HP to 0
- Automatically add the "Unconscious" status to creatures falling below 0 HP


Note:
It seems from the code that wrapping round 1 over and over when traversing backwards through the initiative order might've been an intentional feature. The changes that stop this behaviour were initially created before I made the dark theme visibility update, which means seeing which player was active was difficult.

Testing:
I've tested enabling/disabling and removing/adding new creatures after the changes, and have not noticed any new introduced bugs.