### PR TITLE
Add temporary HP feature and healing overflow settings

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -75,6 +75,7 @@ export interface InitiativeTrackerData {
     displayDifficulty: boolean;
     statuses: Condition[];
     openState: {
+        battle: boolean;
         party: boolean;
         status: boolean;
         plugin: boolean;
@@ -93,9 +94,11 @@ export interface InitiativeTrackerData {
     playerMarker: string;
     monsterMarker: string;
     state: InitiativeViewState;
-    encounters: { [key: string]: InitiativeViewState };
+    encounters: string;
     condense: boolean;
     clamp: boolean;
+    hpOverflow: string;
+    additiveTemp: boolean;
     autoStatus: boolean;
     warnedAboutImports: boolean;
 }
@@ -107,10 +110,12 @@ export interface InitiativeViewState {
     round: number;
 }
 
+
 export interface CreatureState extends HomebrewCreature {
     status: string[];
     enabled: boolean;
     currentHP: number;
+    tempHP: number;
     initiative: number;
     player: boolean;
     xp: number;

--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -94,7 +94,7 @@ export interface InitiativeTrackerData {
     playerMarker: string;
     monsterMarker: string;
     state: InitiativeViewState;
-    encounters: string;
+    encounters: { [key: string]: InitiativeViewState };
     condense: boolean;
     clamp: boolean;
     hpOverflow: string;

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Once all of the creatures in a given combat have been added, initiatives can be 
 
 ### HP
 
-Creatures can take damage or healing by clicking on their HP.
+Creatures can take damage, be healed or gain temporary HP by clicking on their HP.
 
 ### Actions
 
@@ -340,14 +340,42 @@ The setting tab has several options for adding and managing players and homebrew
 ## Basic Settings
 
 ### Display Encounter Difficulty
+`Default: Enabled`
 
 The plugin will calculate and display encounter difficulty based on the challenge rating of the creatures and levels of your party members.
 
 Creatures and players without this information will be ignored for the calculation.
 
 ### Roll Equivalent Creatures Together
+`Default: Enabled`
 
 Equivalent creatures (same HP, AC, and Name) will roll initiatives as a group.
+
+## Battle
+
+### Clamp Minimum HP
+`default: Enabled`
+
+When a creature takes damage that would reduce its HP below 0, its HP is set to 0 instead.
+
+### Overflow Healing
+`default: Ignore`
+
+Set what happens to healing which goes above creatures' max HP threshold.
+
+  - Ignore: Any healing above the creature's max HP is ignored
+  - Temp: Any healing above the creature's max HP is added as temporary HP
+  - Current: Any healing above the creature's max HP is added to the current HP total
+
+### Automatic Unconscious Status Application
+`Default: Enabled`
+
+When a creature takes damage that would reduce its HP below 0, it gains the "Unconscious" status effect.
+
+### Additive Temporary HP
+`Default: Disabled`
+
+Any temporary HP added to a creature will be added on top of exsiting temporary HP.
 
 ## Players
 
@@ -387,20 +415,19 @@ If any default statuses are deleted, you can re-add them by clicking the "Re-add
 ## Plugin Integrations
 
 ### Sync Monsters from TTRPG Statblocks Plugin
-
+`Default: Disabled`
 If the [5e Statblocks](https://github.com/valentine195/obsidian-5e-statblocks) plugin is installed, the homebrew creatures saved to that plugin can be used in this plugin by enabling the sync in settings.
 
 ### Initiative Formula
-
+`Default: 1d20 + %mod%`
 > This setting can only be modified when the [Dice Roller](https://github.com/valentine195/obsidian-dice-roller) plugin is installed.
 
-This setting can be used to modify how a creature's initiative is calculated by the plugin. Use `%mod` as a placeholder for the creature's initiative modifier.
-
-It defaults to `1d20 + %mod%`.
+This setting can be used to modify how a creature's initiative is calculated by the plugin. Use `%mod%` as a placeholder for the creature's initiative modifier.
 
 This will support any dice formula supported by the Dice Roller plugin.
 
 ### Integrate with Obsidian Leaflet
+`Default: Disabled`
 
 If the [Obsidian Leaflet](https://github.com/valentine195/obsidian-leaflet-plugin) plugin is installed, it can be used as a battle map for encounters by turning this setting on.
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -37,12 +37,23 @@ export default class InitiativeTrackerSettings extends PluginSettingTab {
             this._displayBase(containerEl.createDiv());
             if (!this.plugin.data.openState) {
                 this.plugin.data.openState = {
+                    battle: true,
                     player: true,
                     party: true,
                     plugin: true,
                     status: true
                 };
             }
+            this._displayBattle(
+                containerEl.createEl("details", {
+                    cls: "initiative-tracker-additional-container",
+                    attr: {
+                        ...(this.plugin.data.openState.player
+                            ? { open: true }
+                            : {})
+                    }
+                })
+            );
             this._displayPlayers(
                 containerEl.createEl("details", {
                     cls: "initiative-tracker-additional-container",
@@ -134,29 +145,6 @@ export default class InitiativeTrackerSettings extends PluginSettingTab {
                     await this.plugin.saveSettings();
                 });
             });
-            new Setting(containerEl)
-            .setName("Clamp Minimum HP")
-            .setDesc(
-                "When a creature takes damage that would reduce its HP below 0, its HP is set to 0 instead."
-            )
-            .addToggle((t) => {
-                t.setValue(this.plugin.data.clamp).onChange(async (v) => {
-                    this.plugin.data.clamp = v;
-                    await this.plugin.saveSettings();
-                });
-            });
-            new Setting(containerEl)
-            .setName("Automatic Unconscious Status Application")
-            .setDesc(
-                "When a creature takes damage that would reduce its HP below 0, it gains the \"Unconscious\" status effect."
-            )
-            .addToggle((t) => {
-                t.setValue(this.plugin.data.autoStatus).onChange(async (v) => {
-                    this.plugin.data.autoStatus = v;
-                    await this.plugin.saveSettings();
-                });
-            });
-
         /*         new Setting(containerEl)
             .setName("Monster Property used for Modifier")
             .setDesc(
@@ -172,6 +160,63 @@ export default class InitiativeTrackerSettings extends PluginSettingTab {
                     await this.plugin.saveSettings();
                 };
             }); */
+    }
+    private _displayBattle(additionalContainer: HTMLDetailsElement) {
+        additionalContainer.empty();
+        additionalContainer.ontoggle = () => {
+            this.plugin.data.openState.battle = additionalContainer.open;
+        };
+        const summary = additionalContainer.createEl("summary");
+        new Setting(summary).setHeading().setName("Battle");
+        summary.createDiv("collapser").createDiv("handle");
+        new Setting(additionalContainer)
+        .setName("Clamp Minimum HP")
+        .setDesc(
+            "When a creature takes damage that would reduce its HP below 0, its HP is set to 0 instead."
+        )
+        .addToggle((t) => {
+            t.setValue(this.plugin.data.clamp).onChange(async (v) => {
+                this.plugin.data.clamp = v;
+                await this.plugin.saveSettings();
+            });
+        });
+        new Setting(additionalContainer)
+        .setName("Overflow Healing")
+        .setDesc(
+            "Set what happens to healing which goes above creatures' max HP threshold."
+        )
+        .addDropdown((d) => {
+            d.addOption("ignore", "Ignore");
+            d.addOption("temp", "Add to temp HP");
+            d.addOption("current", "Add to current HP");
+            d.setValue(this.plugin.data.hpOverflow ?? "ignore");
+            d.onChange(async (v) => {
+                this.plugin.data.hpOverflow = v;
+                this.plugin.saveSettings();
+            });
+        });
+        new Setting(additionalContainer)
+        .setName("Automatic Unconscious Status Application")
+        .setDesc(
+            "When a creature takes damage that would reduce its HP below 0, it gains the \"Unconscious\" status effect."
+        )
+        .addToggle((t) => {
+            t.setValue(this.plugin.data.autoStatus).onChange(async (v) => {
+                this.plugin.data.autoStatus = v;
+                await this.plugin.saveSettings();
+            });
+        });
+        new Setting(additionalContainer)
+        .setName("Additive Temporary HP")
+        .setDesc(
+            "Any temporary HP added to a creature will be added on top of existing temporary HP."
+        )
+        .addToggle((t) => {
+            t.setValue(this.plugin.data.additiveTemp).onChange(async (v) => {
+                this.plugin.data.additiveTemp = v;
+                await this.plugin.saveSettings();
+            });
+        });
     }
     private _displayPlayers(additionalContainer: HTMLDetailsElement) {
         additionalContainer.empty();

--- a/src/svelte/App.svelte
+++ b/src/svelte/App.svelte
@@ -41,8 +41,11 @@
     }
 
     export let updatingHP: Creature = null;
-    const updateHP = (toAdd: number) => {
-        view.updateCreature(updatingHP, { hp: -1 * toAdd });
+    const updateHP = (toAdd: string) => {
+        if (toAdd[0] == 't')
+            view.updateCreature(updatingHP, { temp: Number(toAdd.slice(1)) })
+        else
+            view.updateCreature(updatingHP, { hp: -1 * Number(toAdd) });
         updatingHP = null;
     };
 
@@ -140,12 +143,13 @@
     <!-- This is disgusting. TODO: Fix it! -->
     {#if updatingHP}
         <div class="updating-hp">
-            <span>Apply damage(+) or healing(-):</span>
+            <span>Apply damage, healing(-) or temp HP(t):</span>
             <!-- svelte-ignore a11y-autofocus -->
             <input
-                type="number"
+                type="text"
+
                 on:blur={function (evt) {
-                    updateHP(Number(this.value));
+                    updateHP(this.value);
                 }}
                 on:keydown={function (evt) {
                     if (evt.key === "Enter" || evt.key === "Tab") {
@@ -159,8 +163,8 @@
                         return;
                     }
                     if (
-                        !/^(-?\d*\.?\d*|Backspace|Delete|Arrow\w+)$/.test(
-                            evt.key
+                        !/^(t?-?\d*\.?\d*(Backspace|Delete|Arrow\w+)?)$/.test(
+                            this.value + evt.key
                         )
                     ) {
                         evt.preventDefault();

--- a/src/svelte/Creature.svelte
+++ b/src/svelte/Creature.svelte
@@ -60,13 +60,14 @@
 </td>
 
 <td class="center hp-container">
-    <span
+    <div
         class="editable"
         on:click={(e) => {
             dispatch("hp", creature);
             e.stopPropagation();
-        }}>{creature.hpDisplay}</span
-    >
+        }}>
+        {@html creature.hpDisplay}
+    </div>
 </td>
 
 <td class="center ac-container">{creature.ac ?? DEFAULT_UNDEFINED}</td>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -29,12 +29,13 @@ export const DEFAULT_SETTINGS: InitiativeTrackerData = {
         round: null
     },
     condense: false,
-    clamp: false,
-    autoStatus: false,
+    clamp: true,
+    autoStatus: true,
     displayDifficulty: true,
     encounters: {},
     warnedAboutImports: false,
     openState: {
+        battle: true,
         party: true,
         status: true,
         plugin: true,
@@ -78,3 +79,9 @@ export const XP_PER_CR: Record<string, number> = {
     "29": 135000,
     "30": 155000
 };
+
+export const OVERFLOW_TYPE: {[key: string]: string} = {
+    ignore: "ignore",
+    current: "current",
+    temp: "temp"
+}

--- a/src/utils/creature.ts
+++ b/src/utils/creature.ts
@@ -4,6 +4,7 @@ import type {
     HomebrewCreature,
     SRDMonster
 } from "@types";
+import { stat } from "fs";
 import type InitiativeTracker from "src/main";
 import { Conditions, XP_PER_CR } from ".";
 import { DEFAULT_UNDEFINED } from "./constants";
@@ -21,6 +22,7 @@ export class Creature {
     name: string;
     modifier: number;
     hp: number;
+    temp: number;
     ac: number;
     note: string;
     enabled: boolean = true;
@@ -54,6 +56,7 @@ export class Creature {
         this.marker = creature.marker;
 
         this.hp = this.max;
+        this.temp = 0;
         this.source = creature.source;
 
         if ("xp" in creature) {
@@ -65,7 +68,10 @@ export class Creature {
     }
     get hpDisplay() {
         if (this.max) {
-            return `${this.hp}/${this.max}`;
+            const tempMods = this.temp > 0 ? `title="Temp HP: ${this.temp}" style="font-weight:bold"`:''
+            return `
+                <span ${tempMods}>${this.hp + this.temp}</span><span>/${this.max}</span>
+            `
         }
         return DEFAULT_UNDEFINED;
     }
@@ -147,6 +153,7 @@ export class Creature {
             id: this.id,
             marker: this.marker,
             currentHP: this.hp,
+            tempHP: this.temp,
             status: Array.from(this.status).map((c) => c.name),
             enabled: this.enabled,
             level: this.level,
@@ -160,6 +167,7 @@ export class Creature {
         const creature = new Creature(state, state.initiative);
         creature.enabled = state.enabled;
 
+        creature.temp = state.tempHP ? state.tempHP : 0;
         creature.hp = state.currentHP;
         let statuses: Condition[] = [];
         for (const status of state.status) {

--- a/src/utils/creature.ts
+++ b/src/utils/creature.ts
@@ -4,7 +4,6 @@ import type {
     HomebrewCreature,
     SRDMonster
 } from "@types";
-import { stat } from "fs";
 import type InitiativeTracker from "src/main";
 import { Conditions, XP_PER_CR } from ".";
 import { DEFAULT_UNDEFINED } from "./constants";
@@ -68,7 +67,7 @@ export class Creature {
     }
     get hpDisplay() {
         if (this.max) {
-            const tempMods = this.temp > 0 ? `title="Temp HP: ${this.temp}" style="font-weight:bold"`:''
+            const tempMods = this.temp > 0 ? `aria-label="Temp HP: ${this.temp}" style="font-weight:bold"`:''
             return `
                 <span ${tempMods}>${this.hp + this.temp}</span><span>/${this.max}</span>
             `


### PR DESCRIPTION
- Can now add temporary HP when applying damage/healing by prefixing with t
    - prefixing with both t and - will remove temp HP (to a minimum of 0)
- Any creature with temp HP will have their current HP displayed in bold text
- Hover over a creature's current HP to see how much of it is temp HP
    - Intentionally does not appear when temp HP is 0, but this can be changed if desired
- Moved previously added HP settings to its own menu under "Battle", along with "Addtive Temporary HP" and "Healing Overflow"
    - Additive Temporary HP is added as a option for edge cases where one might not want temp HP to be overwritten
    - Healing Overflow grant three different options for how to handle healing above a creature's max HP
        - Ignore: HP above the max HP threshold is ignored
        - Temp: HP above the max HP threshold is added to temp HP
        - Current: HP above the max HP threshold is added to the current HP
- Default "Battle" settings changed to match DnD standards
- README updated with new features and defaults

Testing: I believe I've tested all combinations of overflow and additive temp hp in all valid states

Note: I set the default overflow behaviour to "ignore", which differs from how overflow has been handled thus far (equivalent of "current" setting), which may cause surprises for users who have used the overflow intentionally if they're not alerted about the change. Have a feeling most new users would prefer "ignore" as default though.