### PR TITLE
Add damage/healing to multiple creatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,12 +285,12 @@ This command can be used to start or stop an encounter.
 
 #### Applying Damage And Status Effects
 
-A single creature can be selected for damage and status effect application by clicking on their HP display, making them appear in a separate table where application can be adjusted.
+Creatures can be selected for damage and status effect application by clicking on their HP display, making them appear in a separate table where application can be adjusted.
 
 The plugin's behaviour when selecting creatures in this fashion can be adjusted by holding the following buttons:
-  - CTRL/META: multiple creatures can be selected for damage and status effect application
+  - CTRL/META: creature will be marked as having resistance to the damage type (damage is halved)
   - SHIFT: creature will be marked as having succeeded their saving throw (damage is halved and no status effect is applied)
-  - ALT: creature will be marked as having resistance to the damage type (damage is halved)
+  - ALT: creature will have its custom damage modifier set to 2 (damage is doubled)
 
 #### Next Combatant
 

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Creatures can take damage, be healed or gain temporary HP by clicking on their H
 
 ### Actions
 
-Creatures may be edited, disabled / removed from the combat, or statuses (such as "poisoned") may be added to them in the `Actions` menu located to the right of each creature.
+Creatures may be edited, disabled / removed from the combat in the `Actions` menu located to the right of each creature.
 
 ### Controls
 
@@ -282,6 +282,15 @@ If the initiative tracker view has been closed for any reason, use this command 
 #### Toggle Encounter
 
 This command can be used to start or stop an encounter.
+
+#### Applying Damage And Status Effects
+
+A single creature can be selected for damage and status effect application by clicking on their HP display, making them appear in a separate table where application can be adjusted.
+
+The plugin's behaviour when selecting creatures in this fashion can be adjusted by holding the following buttons:
+  - CTRL/META: multiple creatures can be selected for damage and status effect application
+  - SHIFT: creature will be marked as having succeeded their saving throw (damage is halved and no status effect is applied)
+  - ALT: creature will be marked as having resistance to the damage type (damage is halved)
 
 #### Next Combatant
 

--- a/src/svelte/App.svelte
+++ b/src/svelte/App.svelte
@@ -4,7 +4,7 @@
     import Create from "./Create.svelte";
     import type TrackerView from "src/view";
     import { Creature } from "src/utils/creature";
-    import { ExtraButtonComponent, setIcon, SliderComponent, ValueComponent } from "obsidian";
+    import { ExtraButtonComponent, setIcon } from "obsidian";
     import { ADD, COPY, HP, TAG } from "src/utils";
     import { ConditionSuggestionModal } from "src/utils/suggester";
     import type { Condition } from "@types";
@@ -14,8 +14,6 @@
     import Difficulty from "./Difficulty.svelte";
     import SaveEncounter from "./SaveEncounter.svelte";
     import LoadEncounter from "./LoadEncounter.svelte";
-import { log } from "console";
-import { attr } from "svelte/internal";
 
     const dispatch = createEventDispatcher();
 
@@ -66,7 +64,8 @@ import { attr } from "svelte/internal";
                 (resist[index] ? 0.5 : 1) *
                 Number(customMod[index])
             )
-            let toAdd = -1 * Number(toAddString) * modifier;
+            let toAdd = Number(toAddString)
+            toAdd = -1 * Math.sign(toAdd) * Math.max(Math.abs(toAdd) * modifier, 1);
             toAdd = roundHalf ? Math.trunc(toAdd) : toAdd;
             view.updateCreature(creature, { hp: toAdd });
             tag && !saved[index] && view.addStatus(updatingList[index], tag);

--- a/src/svelte/App.svelte
+++ b/src/svelte/App.svelte
@@ -151,7 +151,7 @@
         {state}
         on:hp={(evt) => {
             multiSelect = evt.detail.ctrl;
-            let index = updatingCreatures.findIndex(creature => creature == evt.detail.creature);
+            let index = updatingCreatures.findIndex(entry => entry.creature == evt.detail.creature);
             if (index == -1) {
                 if (!multiSelect) {
                     updatingCreatures.length = 0;
@@ -162,9 +162,10 @@
                     resist:     evt.detail.alt,
                     customMod:  "1",
                 }];
+                console.log(updatingCreatures)
             }
-            else if (index && multiSelect) {
-                updatingCreatures.splice(index, 0);
+            else if (index >= 0 && multiSelect) {
+                updatingCreatures.splice(index, 1);
             }
             else if (!multiSelect) {
                 updatingCreatures.length = 0;

--- a/src/svelte/App.svelte
+++ b/src/svelte/App.svelte
@@ -63,19 +63,24 @@
                 (saved[index] ? 0.5 : 1) * 
                 (resist[index] ? 0.5 : 1) *
                 Number(customMod[index])
-            )
-            let toAdd = Number(toAddString)
+            );
+            let toAdd = Number(toAddString);
             toAdd = -1 * Math.sign(toAdd) * Math.max(Math.abs(toAdd) * modifier, 1);
             toAdd = roundHalf ? Math.trunc(toAdd) : toAdd;
             view.updateCreature(creature, { hp: toAdd });
             tag && !saved[index] && view.addStatus(updatingList[index], tag);
-        })
+        });
+        closeUpdateCreatures();
+    };
 
+    const closeUpdateCreatures = () => {
         updatingList.length = 0;
         saved.length = 0;
         resist.length = 0;
         customMod.length = 0;
-    };
+        damage = "";
+        status = null;
+    }
 
     let addNew = false;
     export let addNewAsync = false;
@@ -208,7 +213,7 @@
                         return;
                     }
                     if (evt.key === "Escape") {
-                        this.value = "";
+                        closeUpdateCreatures();
                         return;
                     }
                     if (
@@ -235,7 +240,7 @@
                 }}
                 on:keydown={function (evt) {
                     if (evt.key === "Escape") {
-                        this.value = "";
+                        closeUpdateCreatures();
                         return;
                     }
                     if (evt.key === "Enter") {

--- a/src/svelte/Creature.svelte
+++ b/src/svelte/Creature.svelte
@@ -9,6 +9,7 @@
     import Status from "./Status.svelte";
 
     export let creature: Creature;
+    export let updatingHP: Creature[] = [];
     $: statuses = creature.status;
 
     const dispatch = createEventDispatcher();
@@ -59,11 +60,22 @@
     </div>
 </td>
 
-<td class="center hp-container">
+<td class={`center hp-container ${updatingHP.find(
+        (entry) => (
+            entry.name == creature.name
+            )
+        ) ? "updating-this-hp" : ""}`}>
     <span
         class="editable"
         on:click={(e) => {
-            dispatch("hp", creature);
+            dispatch(
+                "hp", 
+                {
+                    creature: creature, 
+                    ctrl: e.getModifierState('Control'), 
+                    shift: e.getModifierState('Shift')
+                }
+            );
             e.stopPropagation();
         }}>{creature.hpDisplay}</span
     >
@@ -116,5 +128,12 @@
     .controls-container {
         border-top-right-radius: 0.25rem;
         border-bottom-right-radius: 0.25rem;
+    }
+
+    .updating-this-hp {
+        background-color: rgba(0, 0, 0, 0.1);
+    }
+    :global(.theme-dark) .updating-this-hp {
+        background-color: rgba(255, 255, 255, 0.1);
     }
 </style>

--- a/src/svelte/Creature.svelte
+++ b/src/svelte/Creature.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { createEventDispatcher, getContext } from "svelte";
 
-    import { DEFAULT_UNDEFINED } from "src/utils";
+    import { DEFAULT_UNDEFINED, META_MODIFIER } from "src/utils";
     import type { Creature } from "src/utils/creature";
     import type TrackerView from "src/view";
     import Initiative from "./Initiative.svelte";
@@ -67,7 +67,7 @@
                 "hp", 
                 {
                     creature: creature, 
-                    ctrl: e.getModifierState('Control'), 
+                    ctrl: e.getModifierState(META_MODIFIER), 
                     shift: e.getModifierState('Shift'),
                     alt: e.getModifierState('Alt')
                 }

--- a/src/svelte/Creature.svelte
+++ b/src/svelte/Creature.svelte
@@ -9,7 +9,6 @@
     import Status from "./Status.svelte";
 
     export let creature: Creature;
-    export let updatingHP: Creature[] = [];
     $: statuses = creature.status;
 
     const dispatch = createEventDispatcher();
@@ -60,11 +59,7 @@
     </div>
 </td>
 
-<td class={`center hp-container ${updatingHP.find(
-        (entry) => (
-            entry.name == creature.name
-            )
-        ) ? "updating-this-hp" : ""}`}>
+<td class="center hp-container">
     <span
         class="editable"
         on:click={(e) => {
@@ -73,7 +68,8 @@
                 {
                     creature: creature, 
                     ctrl: e.getModifierState('Control'), 
-                    shift: e.getModifierState('Shift')
+                    shift: e.getModifierState('Shift'),
+                    alt: e.getModifierState('Alt')
                 }
             );
             e.stopPropagation();
@@ -128,12 +124,5 @@
     .controls-container {
         border-top-right-radius: 0.25rem;
         border-bottom-right-radius: 0.25rem;
-    }
-
-    .updating-this-hp {
-        background-color: rgba(0, 0, 0, 0.1);
-    }
-    :global(.theme-dark) .updating-this-hp {
-        background-color: rgba(255, 255, 255, 0.1);
     }
 </style>

--- a/src/svelte/CreatureControls.svelte
+++ b/src/svelte/CreatureControls.svelte
@@ -26,13 +26,6 @@
                         dispatch("edit", creature);
                     });
             });
-            menu.addItem((item) => {
-                item.setIcon(TAG)
-                    .setTitle("Add Status")
-                    .onClick(() => {
-                        dispatch("tag", creature);
-                    });
-            });
             if (creature.enabled) {
                 menu.addItem((item) => {
                     item.setIcon(DISABLE)

--- a/src/svelte/Table.svelte
+++ b/src/svelte/Table.svelte
@@ -10,7 +10,6 @@
     import { createEventDispatcher, getContext } from "svelte";
     import type TrackerView from "src/view";
 
-    export let updatingHP: Creature[] = [];
     export let creatures: Creature[] = [];
     export let state: boolean;
 
@@ -68,13 +67,6 @@
                 .setTitle("Edit")
                 .onClick(() => {
                     dispatch("edit", creature);
-                });
-        });
-        menu.addItem((item) => {
-            item.setIcon(TAG)
-                .setTitle("Add Status")
-                .onClick(() => {
-                    dispatch("tag", creature);
                 });
         });
         if (creature.enabled) {
@@ -159,7 +151,7 @@
                         on:click={() => openView(creature)}
                         on:contextmenu={(evt) => hamburgerIcon(evt, creature)}
                     >
-                        <CreatureTemplate {creature} {updatingHP} on:hp on:tag on:edit />
+                        <CreatureTemplate {creature} on:hp on:tag on:edit />
                     </tr>
                 {/each}
             </tbody>

--- a/src/svelte/Table.svelte
+++ b/src/svelte/Table.svelte
@@ -10,6 +10,7 @@
     import { createEventDispatcher, getContext } from "svelte";
     import type TrackerView from "src/view";
 
+    export let updatingHP: Creature[] = [];
     export let creatures: Creature[] = [];
     export let state: boolean;
 
@@ -158,7 +159,7 @@
                         on:click={() => openView(creature)}
                         on:contextmenu={(evt) => hamburgerIcon(evt, creature)}
                     >
-                        <CreatureTemplate {creature} on:hp on:tag on:edit />
+                        <CreatureTemplate {creature} {updatingHP} on:hp on:tag on:edit />
                     </tr>
                 {/each}
             </tbody>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,4 +1,5 @@
 import type { InitiativeTrackerData } from "@types";
+import { Platform } from "obsidian";
 import { Conditions } from "./conditions";
 
 export const INTIATIVE_TRACKER_VIEW = "initiative-tracker-view";
@@ -7,6 +8,8 @@ export const CREATURE_TRACKER_VIEW = "initiative-tracker-creature-view";
 export const MIN_WIDTH_FOR_HAMBURGER = 300;
 
 export const DEFAULT_UNDEFINED = "–";
+
+export const META_MODIFIER = Platform.isMacOS ? "Meta" : "Control";
 
 export const DEFAULT_SETTINGS: InitiativeTrackerData = {
     players: [],

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -40,7 +40,9 @@ export const DEFAULT_SETTINGS: InitiativeTrackerData = {
         status: true,
         plugin: true,
         player: true
-    }
+    },
+    hpOverflow: "ignore",
+    additiveTemp: false
 };
 
 export const XP_PER_CR: Record<string, number> = {


### PR DESCRIPTION
- Multiple creatures can now be selected at once for damage/healing application in the table view
    - Select multiple creatures by clicking while holding CTRL
    - Apply half damage/healing by clicking while holding ALT
    - Apply "successful saving throw" (half damage/healing + no condition applied) by clicking while holding SHIFT
        - Half damage/healing is always rounded down, unless the number provided contains a ".", e.g.:
            - 5/2 = 2
            - 5./2 = 2.5
            - 5.3/2 = 2.65
- Creatures selected for damage/healing application are put into a separate table at the bottom of the view
    - Useful for differentiating between creatures succeeding/failing saving throws
    - Tablet users can easily set the "saved" and "resist" properties using the UI
    - The extra modifier field can be used for effects like a Grave Cleric's "Path To The Grave" ability, which doubles the next damage a creature receives (or just plain vulnerability)
- The conditions field is added underneath the damage field to allow easy application of both to multiple creatures
    - Due to SHIFT's functionality, conditions can be applied to only those creatures who fail their saving throws
- Hitting enter in either the damage application field or the status application field will apply the values in both fields to selected creatures with their specified modifiers

Testing: Selecting single creatures, multiple creatures, multiple then single creature, single then multiple, with and without status, only selecting status. All these with/without modifiers, often differentiating between the selection.

Note: To make multiselect work, I had to remove damage application on blur for the updating-hp input field. Instead, damage/healing is applied by clicking enter. There might exist a workaround, but as users will have their fingers near the enter button while inputting HP, I don't believe this implementation will cause much problem.