### PR TITLE
Fixed encounter difficulty

### DIFF
--- a/src/encounter/ui/EncounterRow.svelte
+++ b/src/encounter/ui/EncounterRow.svelte
@@ -22,9 +22,9 @@
     export let plugin: InitiativeTracker;
     export let headers: string[];
 
-    const creatureMap: Map<Creature, number> = new Map();
+    let totalXP: number;
+    let creatureMap: Map<Creature, number> = new Map();
     const rollerMap: Map<Creature, StackRoller> = new Map();
-    let totalXP = [...creatureMap].reduce((a, c) => a + c[0].xp * c[1], 0);
 
     for (let [creature, count] of creatures) {
         let number: number = Number(count);
@@ -32,6 +32,7 @@
             let roller = plugin.getRoller(`${count}`) as StackRoller;
             roller.on("new-result", () => {
                 creatureMap.set(creature, roller.result);
+                creatureMap = creatureMap;
                 totalXP = [...creatureMap].reduce(
                     (a, c) => a + c[0].xp * c[1],
                     0
@@ -43,12 +44,15 @@
             creatureMap.set(creature, number);
         }
     }
+    totalXP = [...creatureMap].reduce((a, c) => a + c[0].xp * c[1], 0);
     let difficulty: DifficultyReport;
     $: {
         if (!isNaN(totalXP)) {
             difficulty = encounterDifficulty(
                 playerLevels,
-                [...creatures].map((creature) => creature[0].xp)
+                [...creatureMap]
+                .map((creature) => Array(creature[1]).fill(creature[0].xp))
+                .flat()
             );
         }
     }


### PR DESCRIPTION
Fixes #50 

Turns out this is fixed using the same changes as in #43.
[To fix this](https://github.com/g-bauer/obsidian-initiative-tracker/blob/fix_encounter_table_difficulty/src/encounter/ui/EncounterRow.svelte#L47-L58) we now create an array for each monster type with the length of the array equal to the number of monsters of that type and fill it with XP values. 