### PR TITLE
fix: remove creature selection shortcut overload

### DIFF
--- a/src/svelte/Creature.svelte
+++ b/src/svelte/Creature.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { createEventDispatcher, getContext } from "svelte";
 
-    import { DEFAULT_UNDEFINED, META_MODIFIER } from "src/utils";
+    import { DEFAULT_UNDEFINED } from "src/utils";
     import type { Creature } from "src/utils/creature";
     import type TrackerView from "src/view";
     import Initiative from "./Initiative.svelte";
@@ -37,7 +37,7 @@
     />
 </td>
 <td class="name-container">
-    <div class="name-holder">
+    <div class="name-holder" on:click={() => view.openCombatant(creature)}>
         {#if creature.player}
             <strong class="name player">{creature.name}</strong>
         {:else}
@@ -59,26 +59,13 @@
     </div>
 </td>
 
-<td class="center hp-container">
-    <div
-        class="editable"
-        on:click={(e) => {
-            dispatch(
-                "hp", 
-                {
-                    creature: creature, 
-                    ctrl: e.getModifierState(META_MODIFIER), 
-                    shift: e.getModifierState('Shift'),
-                    alt: e.getModifierState('Alt')
-                }
-            );
-            e.stopPropagation();
-        }}>
+<td class="center hp-container creature-adder">
+    <div>
         {@html creature.hpDisplay}
     </div>
 </td>
 
-<td class="center ac-container">{creature.ac ?? DEFAULT_UNDEFINED}</td>
+<td class="center ac-container creature-adder">{creature.ac ?? DEFAULT_UNDEFINED}</td>
 
 <td class="controls-container">
     <CreatureControls
@@ -109,7 +96,7 @@
     .center {
         text-align: center;
     }
-    .editable:not(.player) {
+    .creature-adder {
         cursor: pointer;
     }
 

--- a/src/svelte/Table.svelte
+++ b/src/svelte/Table.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
     import { Menu, Platform, setIcon } from "obsidian";
-    import { AC, DISABLE, ENABLE, HP, MAPMARKER, REMOVE, TAG } from "src/utils";
+    import { AC, DISABLE, ENABLE, HP, MAPMARKER, REMOVE, META_MODIFIER } from "src/utils";
 
     import { flip } from "svelte/animate";
     import { dndzone } from "svelte-dnd-action";
@@ -12,9 +12,6 @@
 
     export let creatures: Creature[] = [];
     export let state: boolean;
-
-    const clickModifier =
-        Platform.isMacOS || Platform.isIosApp ? "Meta" : "Control";
 
     const dispatch = createEventDispatcher();
 
@@ -57,10 +54,6 @@
         items = e.detail.items;
         view.setCreatures(items.map(({ creature }) => creature));
     }
-
-    const openView = (creature: Creature) => {
-        view.openCombatant(creature);
-    };
 
     const hamburgerIcon = (evt: MouseEvent, creature: Creature) => {
         evt.stopPropagation();
@@ -153,16 +146,17 @@
                         data-hp-percent={Math.round(
                             ((creature.hp ?? 0) / creature.max) * 100 ?? 0
                         )}
-                        on:click={(evt) => {
-                            console.log(
-                                clickModifier,
-                                evt.getModifierState(clickModifier)
+                        on:click={(e) => {
+                            dispatch(
+                                "hp", 
+                                {
+                                    creature: creature, 
+                                    ctrl: e.getModifierState(META_MODIFIER), 
+                                    shift: e.getModifierState('Shift'),
+                                    alt: e.getModifierState('Alt')
+                                }
                             );
-                            if (evt.getModifierState(clickModifier)) {
-                                dispatch("hp", { creature });
-                                return;
-                            }
-                            openView(creature);
+                            e.stopPropagation();
                         }}
                         on:contextmenu={(evt) => hamburgerIcon(evt, creature)}
                     >


### PR DESCRIPTION
closes #57

- holding ctrl/meta now doesn't always add creature to damage/staus application
- clicking specifically on the name of a creature will open its statblock
- clicking a creature's HP or AC field will always add a creature to damage/status application

Check-in to: master