### PR TITLE
feat: Add option to remove beginner tips

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -72,6 +72,7 @@ interface Party {
 }
 
 export interface InitiativeTrackerData {
+    beginnerTips: boolean;
     displayDifficulty: boolean;
     statuses: Condition[];
     openState: {

--- a/README.md
+++ b/README.md
@@ -348,6 +348,11 @@ The setting tab has several options for adding and managing players and homebrew
 
 ## Basic Settings
 
+### Display Beginner Tips
+`Default: Enabled`
+
+Display instructions in the intiative tracker, helping you get used to the workflow.
+
 ### Display Encounter Difficulty
 `Default: Enabled`
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -118,6 +118,19 @@ export default class InitiativeTrackerSettings extends PluginSettingTab {
         containerEl.empty();
         new Setting(containerEl).setHeading().setName("Basic Settings");
         new Setting(containerEl)
+        .setName("Display Beginner Tips")
+        .setDesc(
+            "Display instructions in the intiative tracker, helping you get used to the workflow."
+        )
+        .addToggle((t) => {
+            t.setValue(this.plugin.data.beginnerTips).onChange(
+                async (v) => {
+                    this.plugin.data.beginnerTips = v;
+                    await this.plugin.saveSettings();
+                }
+            );
+        });
+        new Setting(containerEl)
             .setName("Display Encounter Difficulty")
             .setDesc(
                 "Display encounter difficulty based on creature CR and player level. Creatures without CR or level will not be considered in the calculation."

--- a/src/svelte/App.svelte
+++ b/src/svelte/App.svelte
@@ -196,9 +196,11 @@
         <div class="updating-hp">
             <!-- svelte-ignore a11y-autofocus -->
             <div class="hp-status">
-                <small class="label">
-                    Apply damage, healing(-) or temp HP(t)
-                </small>
+                {#if plugin.data.beginnerTips}
+                    <small class="label">
+                        Apply damage, healing(-) or temp HP(t)
+                    </small>
+                {/if}
                 <div class="input">
                     <tag
                         use:hpIcon
@@ -232,10 +234,12 @@
                 </div>
             </div>
             <div class="hp-status">
-                <small class="label">
-                    Apply status effect to creatures that fail their saving
-                    throw
-                </small>
+                {#if plugin.data.beginnerTips}
+                    <small class="label">
+                        Apply status effect to creatures that fail their saving
+                        throw
+                    </small>
+                {/if}
                 <div class="input">
                     <tag
                         use:tagIcon
@@ -276,9 +280,11 @@
                 aria-label="Cancel"
             />
         </div>
-        <div>
-            <small>Multiple creatures can be selected at a time.</small>
-        </div>
+        {#if plugin.data.beginnerTips}
+            <div>
+                <small>Multiple creatures can be selected at a time.</small>
+            </div>
+        {/if}
         <div style="margin: 0.5rem">
             <table class="updating-creature-table">
                 <thead class="updating-creature-table-header">
@@ -498,5 +504,6 @@
         display: flex;
         justify-content: flex-end;
         gap: 1rem;
+        margin-right: 1.2rem;
     }
 </style>

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -34,6 +34,7 @@ export const DEFAULT_SETTINGS: InitiativeTrackerData = {
     condense: false,
     clamp: true,
     autoStatus: true,
+    beginnerTips: true,
     displayDifficulty: true,
     encounters: {},
     warnedAboutImports: false,


### PR DESCRIPTION
closes #59

- beginnerTips added as an option
    - hides instructions in UI when disabled
- apply and Cancel buttons aligned with damage/status fields

Check-in to: master