### PR TITLE
Statblock link

### DIFF
--- a/@types/index.d.ts
+++ b/@types/index.d.ts
@@ -74,6 +74,7 @@ interface Party {
 export interface InitiativeTrackerData {
     beginnerTips: boolean;
     displayDifficulty: boolean;
+    preferStatblockLink: boolean;
     statuses: Condition[];
     openState: {
         battle: boolean;
@@ -123,7 +124,6 @@ export interface CreatureState extends HomebrewCreature {
     player: boolean;
     xp: number;
     active: boolean;
-    "statblock-link": string;
 }
 
 export interface SRDMonster {
@@ -172,6 +172,7 @@ export interface HomebrewCreature {
     id?: string;
     xp?: number;
     hidden?: boolean;
+    "statblock-link"?: string;
 }
 
 export type ability =

--- a/src/main.css
+++ b/src/main.css
@@ -147,6 +147,9 @@ body {
 .creature-view-container .creature-view-button {
     display: flex;
     justify-content: flex-end;
+    position: absolute;
+    right: 5px;
+    top: 5px;
 }
 
 .initiative-tracker-encounter-line {

--- a/src/main.ts
+++ b/src/main.ts
@@ -273,12 +273,14 @@ export default class InitiativeTracker extends Plugin {
                         this.app.metadataCache.getFileCache(file)?.frontmatter;
                     if (!frontmatter) return;
                     for (let player of players) {
-                        const { ac, hp, modifier, level } = frontmatter;
+                        const { ac, hp, modifier, level, name } = frontmatter;
                         player.ac = ac;
                         player.hp = hp;
                         player.modifier = modifier;
                         player.level = level;
-
+                        player.name = name ? name : player.name;
+                        this.setStatblockLink(player, frontmatter["statblock-link"]);
+                        
                         this.playerCreatures.set(
                             player.name,
                             Creature.from(player)
@@ -326,6 +328,14 @@ export default class InitiativeTracker extends Plugin {
         });
 
         console.log("Initiative Tracker v" + this.manifest.version + " loaded");
+    }
+    
+    setStatblockLink(player: HomebrewCreature, newValue: string) {
+        if (newValue) {
+            player["statblock-link"] = newValue.startsWith("#") 
+                    ? `[${player.name}](${player.path}${newValue})`
+                    : newValue;
+        }
     }
 
     addCommands() {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1038,12 +1038,14 @@ class NewPlayerModal extends Modal {
                     this.player.name = modal.file.basename;
 
                     if (!metaData || !metaData.frontmatter) return;
+                    const { ac, hp, modifier, level, name } = metaData.frontmatter;
+                    this.player.name = name ? name : this.player.name;
+                    this.player.ac = ac;
+                    this.player.hp = hp;
+                    this.player.level = level;
+                    this.player.modifier = modifier;
+                    this.plugin.setStatblockLink(this.player, metaData.frontmatter["statblock-link"]);
 
-                    const { ac, hp, modifier, level } = metaData.frontmatter;
-                    this.player = {
-                        ...this.player,
-                        ...{ ac, hp, modifier, level }
-                    };
                     this.display();
                 };
             });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -164,6 +164,17 @@ export default class InitiativeTrackerSettings extends PluginSettingTab {
                     await this.plugin.saveSettings();
                 });
             });
+        new Setting(containerEl)
+            .setName("Embed statblock-link content in the Creature View")
+            .setDesc(
+                "Prefer embedded content from a statblock-link attribute when present. Fall back to the TTRPG plugin if the link is missing and the plugin is enabled."
+            )
+            .addToggle((t) => {
+                t.setValue(this.plugin.data.preferStatblockLink).onChange(async (v) => {
+                    this.plugin.data.preferStatblockLink = v;
+                    await this.plugin.saveSettings();
+                });
+            });
         /*         new Setting(containerEl)
             .setName("Monster Property used for Modifier")
             .setDesc(

--- a/src/svelte/Creature.svelte
+++ b/src/svelte/Creature.svelte
@@ -27,7 +27,7 @@
         setIcon(div, "eye-off");
     };
 
-    let hoverTimeout = null;
+    let hoverTimeout: NodeJS.Timeout = null;
     const tryHover = (evt: MouseEvent) => {
         hoverTimeout = setTimeout(() => {
             if (creature["statblock-link"]) {
@@ -56,6 +56,7 @@
     };
 </script>
 
+<!-- svelte-ignore a11y-click-events-have-key-events -->
 <td class="initiative-container" on:click={(e) => e.stopPropagation()}>
     <Initiative
         initiative={creature.initiative}
@@ -67,6 +68,7 @@
     />
 </td>
 <td class="name-container">
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
     <div
         class="name-holder"
         on:click={() => view.openCombatant(creature)}
@@ -82,6 +84,7 @@
             <span class="name">{name()}</span>
         {/if}
     </div>
+    <!-- svelte-ignore a11y-click-events-have-key-events -->
     <div class="statuses" on:click={(e) => e.stopPropagation()}>
         {#if statuses.size}
             {#each [...statuses] as status}

--- a/src/svelte/Creature.svelte
+++ b/src/svelte/Creature.svelte
@@ -27,7 +27,7 @@
         setIcon(div, "eye-off");
     };
 
-    var hoverTimeout = null;
+    let hoverTimeout = null;
     const tryHover = (evt: MouseEvent) => {
         hoverTimeout = setTimeout(() => {
             if (creature["statblock-link"]) {

--- a/src/svelte/Creature.svelte
+++ b/src/svelte/Creature.svelte
@@ -27,25 +27,32 @@
         setIcon(div, "eye-off");
     };
 
+    var hoverTimeout = null;
     const tryHover = (evt: MouseEvent) => {
-        if (creature["statblock-link"]) {
-            let link = creature["statblock-link"];
-            if (/\[.+\]\(.+\)/.test(link)) {
-                //md
-                [, link] = link.match(/\[.+?\]\((.+?)\)/);
-            } else if (/\[\[.+\]\]/.test(link)) {
-                //wiki
-                [, link] = link.match(/\[\[(.+?)(?:\|.+?)?\]\]/);
-            }
+        hoverTimeout = setTimeout(() => {
+            if (creature["statblock-link"]) {
+                let link = creature["statblock-link"];
+                if (/\[.+\]\(.+\)/.test(link)) {
+                    //md
+                    [, link] = link.match(/\[.+?\]\((.+?)\)/);
+                } else if (/\[\[.+\]\]/.test(link)) {
+                    //wiki
+                    [, link] = link.match(/\[\[(.+?)(?:\|.+?)?\]\]/);
+                }
 
-            app.workspace.trigger(
-                "link-hover",
-                {}, //hover popover, but don't need
-                evt.target, //targetEl
-                link, //linkText
-                "initiative-tracker " //source
-            );
-        }
+                app.workspace.trigger(
+                    "link-hover",
+                    {}, //hover popover, but don't need
+                    evt.target, //targetEl
+                    link, //linkText
+                    "initiative-tracker " //source
+                );
+            }
+        }, 1000);
+    };
+    
+    const cancelHover = (evt: MouseEvent) => {
+        clearTimeout(hoverTimeout);
     };
 </script>
 
@@ -64,6 +71,7 @@
         class="name-holder"
         on:click={() => view.openCombatant(creature)}
         on:mouseenter={tryHover}
+        on:mouseleave={cancelHover}
     >
         {#if creature.hidden}
             <div class="centered-icon" use:hiddenIcon />

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -20,6 +20,7 @@ export const DEFAULT_SETTINGS: InitiativeTrackerData = {
     statuses: [...Conditions],
     version: null,
     canUseDiceRoll: false,
+    preferStatblockLink: false,
     initiative: "1d20 + %mod%",
     modifier: null,
     sync: false,

--- a/src/utils/creature.ts
+++ b/src/utils/creature.ts
@@ -39,6 +39,7 @@ export class Creature {
     number = 0;
     display: string;
     "statblock-link": string;
+    
     constructor(public creature: HomebrewCreature, initiative: number = 0) {
         this.name = creature.name;
         this.display = creature.display;
@@ -145,6 +146,7 @@ export class Creature {
         this.note = creature.note;
         this.level = creature.level;
         this.player = creature.player;
+        this["statblock-link"] = creature["statblock-link"];
 
         this.marker = creature.marker;
         this.source = creature.source;

--- a/src/view.ts
+++ b/src/view.ts
@@ -2,13 +2,11 @@ import {
     debounce,
     ExtraButtonComponent,
     ItemView,
-    MarkdownPreviewRenderer,
-    MarkdownPreviewView,
-    Modal,
+    MarkdownRenderer,
     Notice,
-    Platform,
-    Setting,
-    WorkspaceLeaf
+    WorkspaceLeaf,
+    parseLinktext,
+    resolveSubpath
 } from "obsidian";
 import {
     BASE,
@@ -165,7 +163,7 @@ export default class TrackerView extends ItemView {
         );
         this.registerEvent(ref);
 
-        this.plugin.combatant.render(creature);
+        await this.plugin.combatant.render(creature);
     }
     protected creatures: Creature[] = [];
 
@@ -896,15 +894,15 @@ export class CreatureView extends ItemView {
         new ExtraButtonComponent(this.buttonEl)
             .setIcon("cross")
             .setTooltip("Close Statblock")
-            .onClick(() => {
-                this.render();
+            .onClick(async () => {
+                await this.render();
                 this.app.workspace.trigger("initiative-tracker:stop-viewing");
             });
     }
     onunload(): void {
         this.app.workspace.trigger("initiative-tracker:stop-viewing");
     }
-    render(creature?: HomebrewCreature) {
+    async render(creature?: HomebrewCreature) {
         this.statblockEl.empty();
         if (!creature) {
             this.statblockEl.createEl("em", {
@@ -912,11 +910,14 @@ export class CreatureView extends ItemView {
             });
             return;
         }
+        
+        const tryStatblockPlugin = this.plugin.canUseStatBlocks &&
+                this.plugin.statblockVersion?.major >= 2;
 
-        if (
-            this.plugin.canUseStatBlocks &&
-            this.plugin.statblockVersion?.major >= 2
-        ) {
+        if (creature["statblock-link"] && 
+            (this.plugin.data.preferStatblockLink || !tryStatblockPlugin)) {
+            await this.renderEmbed(creature["statblock-link"]);
+        } else if (tryStatblockPlugin) {
             const statblock = this.plugin.statblocks.render(
                 creature,
                 this.statblockEl,
@@ -925,9 +926,38 @@ export class CreatureView extends ItemView {
             this.addChild(statblock);
         } else {
             this.statblockEl.createEl("em", {
-                text: "Install the TTRPG Statblocks plugin to use this feature!"
+                text: "Install the TTRPG Statblocks plugin or add a statblock-link to your monster to use this feature!"
             });
         }
+    }
+    async renderEmbed(embedLink: string) {
+        if (/\[.+\]\(.+\)/.test(embedLink)) {
+            //md
+            [, embedLink] = embedLink.match(/\[.+?\]\((.+?)\)/);
+        } else if (/\[\[.+\]\]/.test(embedLink)) {
+            //wiki
+            [, embedLink] = embedLink.match(/\[\[(.+?)(?:\|.+?)?\]\]/);
+        }
+        
+        const {path, subpath} = parseLinktext(embedLink);
+        const file = this.app.metadataCache.getFirstLinkpathDest(path, '/');
+        const fileContent = await app.vault.cachedRead(file);
+        
+        let content = `Oops! Something is wrong with your statblock-link:<br />${embedLink}`;
+        if (subpath && fileContent) {
+            const cache = app.metadataCache.getFileCache(file);
+            const subpathResult = resolveSubpath(cache, subpath);
+            content = fileContent.slice(subpathResult.start.offset, subpathResult.end.offset);
+        } else if (fileContent) {
+            content = fileContent;
+        }
+        
+        await MarkdownRenderer.renderMarkdown(
+            content,
+            this.statblockEl.createDiv("markdown-rendered"),
+            path,
+            null
+        );
     }
     getDisplayText(): string {
         return "Combatant";

--- a/src/view.ts
+++ b/src/view.ts
@@ -947,7 +947,9 @@ export class CreatureView extends ItemView {
         if (subpath && fileContent) {
             const cache = app.metadataCache.getFileCache(file);
             const subpathResult = resolveSubpath(cache, subpath);
-            content = fileContent.slice(subpathResult.start.offset, subpathResult.end.offset);
+            if (subpathResult) {
+                content = fileContent.slice(subpathResult.start.offset, subpathResult.end.offset);
+            }
         } else if (fileContent) {
             content = fileContent;
         }


### PR DESCRIPTION
- Toggle setting: Render statblock link content in the creature view
- `statblock-link` attribute is parsed (block-ref, section, or full document), and content is included in the creature view
- Added a timeout to make the hover over the monster/creature name in the initiative order less sensitive.